### PR TITLE
Add gitignore, add coordinates to ruins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Files you can tell git to not push
+*.db 
+*.pyc

--- a/main.py
+++ b/main.py
@@ -506,16 +506,21 @@ def ruins():
             if input == '/b':
                 return
             continue
-
+        
         TextPrinter.clear()
         TextPrinter.guide("'/b' to go back.")
         TextPrinter.print('Ruins', TextStyle.HEADER)
 
         for town in ruined_towns:
             TextPrinter.print('--------', TextStyle.GRAY)
+            # Get town coordinates to nearest whole number
+            x_coord = str(round(town['coordinates']['spawn']['x']))
+            y_coord = str(round(town['coordinates']['spawn']['y']))
+            z_coord = str(round(town['coordinates']['spawn']['z']))
             print(BOLD + 'Town: ' + ENDC + town['name'])
             print(BOLD + 'Chunks: ' + ENDC + str(town['stats']['numTownBlocks']))
-            print(BOLD + 'Ruined At: ' + ENDC + Utilities.epochToDatetime(town['timestamps']['ruinedAt']))
+            print(BOLD + 'Ruined At: ' + ENDC + Utilities.epochToDatetime(town['timestamps']['ruinedAt'])) 
+            print(BOLD + 'Coordinates: ' + ENDC + f'X:{x_coord} Y:{y_coord} Z:{z_coord}')
             
         input = TextPrinter.input().strip()
         if input == '/b':


### PR DESCRIPTION
Small pull request to start.

Main changes:
1. Added gitignore to ignore pycache and .db files
2. Display coordinates of ruined towns

This screenshot shows the different outputs (left is new, right is old)
![image](https://github.com/Dec4on/OPENSPY/assets/174749035/f4e4087a-78b4-4fec-8a42-d9a3412140d0)
